### PR TITLE
Enhance damage and status text visibility

### DIFF
--- a/src/css/battle.css
+++ b/src/css/battle.css
@@ -118,20 +118,25 @@
     padding: 5px 10px;
     color: white;
     font-weight: bold;
-    font-size: 16px;
+    font-size: 24px;
     text-transform: uppercase;
     margin-bottom: 5px;
     opacity: 0;
     transform: translateY(0);
+    text-shadow: 
+        -2px -2px 0px #000,
+        2px -2px 0px #000,
+        -2px 2px 0px #000,
+        2px 2px 0px #000,
+        -2px 0px 0px #000,
+        2px 0px 0px #000,
+        0px -2px 0px #000,
+        0px 2px 0px #000;
 }
 .status-notification {
-    color: rgba(175, 100, 255, 1);
-    text-shadow: 0px 0px 3px #000;
     animation: fadeUpAndOut 1s forwards;
 }
 .damage-notification {
-    color: rgba(255, 80, 80, 1);
-    text-shadow: 0px 0px 3px #000;
     animation: fadeUpAndOut 1s forwards;
 }
 @keyframes fadeUpAndOut {


### PR DESCRIPTION
Increase font size and add white color with a black border to damage and status infliction text for improved readability.